### PR TITLE
GSREN3D-272: add arrow on station to POIs on station view

### DIFF
--- a/src/components/map/MapComponent.vue
+++ b/src/components/map/MapComponent.vue
@@ -63,7 +63,7 @@ import { lineStringsFromTraveltimes } from '@/helpers/traveltimesHelper'
 import { apiClientService } from '@/services/api.client'
 import {
   getFeatureByAttribute,
-  getFeaturesByAttribute,
+  filterFeaturesByAttribute,
 } from '@/helpers/layerHelper'
 import { lineStringsFromStationPois } from '@/helpers/stationHelper'
 
@@ -248,7 +248,7 @@ async function updatePOIArrow() {
   ) as GeoJSONLayer
   await poiLayer.fetchData()
 
-  const selectedPoiFeatures = await getFeaturesByAttribute(
+  const selectedPoiFeatures = await filterFeaturesByAttribute(
     'station_nom',
     stationName,
     poiLayer

--- a/src/components/map/MapComponent.vue
+++ b/src/components/map/MapComponent.vue
@@ -9,6 +9,7 @@ import {
   VcsApp,
   EventType,
   Viewpoint,
+  ArrowEnd,
 } from '@vcmap/core'
 import UiMap from '@/components/ui/UiMap.vue'
 import NavigationButtons from '@/components/map/buttons/NavigationButtons.vue'
@@ -272,7 +273,9 @@ async function updateTraveltimeArrow() {
     lineStrings = await lineStringsFromTraveltimes(travelTimes, vcsApp)
   }
   updateArrowFeatures(lineStrings, arrowLayer)
-  updateArrowLayerStyle(arrowLayer, mapStore.is3D())
+  // False negative: Property 'BOTH' does not exist on type 'typeof ArrowEnd'
+  // @ts-ignore
+  updateArrowLayerStyle(arrowLayer, mapStore.is3D(), ArrowEnd.BOTH)
 }
 
 async function updateLineViewStyle() {

--- a/src/helpers/layerHelper.ts
+++ b/src/helpers/layerHelper.ts
@@ -10,3 +10,16 @@ export async function getFeatureByAttribute(
     .getFeatures()
     .find((feature) => feature.getProperty(attribute) === value)
 }
+
+export async function getFeaturesByAttribute(
+  attribute: string,
+  value: string,
+  layer: GeoJSONLayer
+) {
+  await layer.fetchData()
+  const selected = layer
+    .getFeatures()
+    .filter((feature) => feature.getProperty(attribute) === value)
+
+  return selected
+}

--- a/src/helpers/layerHelper.ts
+++ b/src/helpers/layerHelper.ts
@@ -11,7 +11,7 @@ export async function getFeatureByAttribute(
     .find((feature) => feature.getProperty(attribute) === value)
 }
 
-export async function getFeaturesByAttribute(
+export async function filterFeaturesByAttribute(
   attribute: string,
   value: string,
   layer: GeoJSONLayer

--- a/src/helpers/stationHelper.ts
+++ b/src/helpers/stationHelper.ts
@@ -1,0 +1,17 @@
+import { LineString } from 'ol/geom'
+import type Feature from 'ol/Feature'
+
+export async function lineStringsFromStationPois(
+  station: Feature,
+  pois: Feature[]
+) {
+  const promises = pois.map(async (poi) => {
+    const lineString = new LineString([
+      station?.getGeometry()?.getCoordinates(),
+      poi?.getGeometry()?.getCoordinates(),
+    ])
+    return lineString
+  })
+  const lineStrings = await Promise.all(promises)
+  return lineStrings
+}

--- a/src/stores/layers.ts
+++ b/src/stores/layers.ts
@@ -14,6 +14,7 @@ export const RENNES_LAYER = {
   poi: 'poi',
   // The following layers are scratch layers
   _traveltimeArrow: '_traveltimeArrow',
+  _poiArrow: '_poiArrow',
 }
 
 export const RENNES_LAYERNAMES = [
@@ -27,6 +28,7 @@ export const RENNES_LAYERNAMES = [
   RENNES_LAYER.parking,
   RENNES_LAYER.poi,
   RENNES_LAYER._traveltimeArrow,
+  RENNES_LAYER._poiArrow,
 ] as const
 
 export type RennesLayer = typeof RENNES_LAYERNAMES[number]
@@ -44,6 +46,7 @@ export const useLayersStore = defineStore('layers', () => {
     parking: false,
     poi: false,
     _traveltimeArrow: false,
+    _poiArrow: false,
   })
 
   function toggleLayer(name: RennesLayer) {
@@ -66,6 +69,7 @@ export const useLayersStore = defineStore('layers', () => {
       parking: boolean
       poi: boolean
       _traveltimeArrow: boolean
+      _poiArrow: boolean
     }
   ) {
     update3DBaseLayer(is3D)
@@ -74,6 +78,7 @@ export const useLayersStore = defineStore('layers', () => {
     visibilities.value.parking = newVisibilities.parking
     visibilities.value.poi = newVisibilities.poi
     visibilities.value._traveltimeArrow = newVisibilities._traveltimeArrow
+    visibilities.value._poiArrow = newVisibilities._poiArrow
   }
 
   return { visibilities, toggleLayer, update3DBaseLayer, setVisibilities }

--- a/src/styles/arrow.ts
+++ b/src/styles/arrow.ts
@@ -41,7 +41,13 @@ export function updateArrowFeatures(
   arrowLayer.addFeatures(features)
 }
 
-export function updateArrowLayerStyle(arrowLayer: VectorLayer, is3D: boolean) {
+export function updateArrowLayerStyle(
+  arrowLayer: VectorLayer,
+  is3D: boolean,
+  // False negative: Property 'END' does not exist on type 'typeof ArrowEnd'
+  // @ts-ignore
+  end: ArrowEnd = ArrowEnd.END
+) {
   // Update arrow's style
   let arrowColor = '#000000'
   if (is3D) {
@@ -52,9 +58,7 @@ export function updateArrowLayerStyle(arrowLayer: VectorLayer, is3D: boolean) {
       width: 1.5,
       arcFactor: 0.15,
       color: arrowColor,
-      // False negative: Property 'BOTH' does not exist on type 'typeof ArrowEnd'
-      // @ts-ignore
-      end: ArrowEnd.BOTH,
+      end: end,
     })
   )
 }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -27,6 +27,7 @@ onMounted(() => {
     parking: true,
     poi: false,
     _traveltimeArrow: false,
+    _poiArrow: false,
   })
 })
 </script>

--- a/src/views/LineView.vue
+++ b/src/views/LineView.vue
@@ -58,6 +58,7 @@ onMounted(async () => {
     parking: true,
     poi: true,
     _traveltimeArrow: true,
+    _poiArrow: false,
   })
 })
 

--- a/src/views/StationView.vue
+++ b/src/views/StationView.vue
@@ -57,6 +57,7 @@ onMounted(async () => {
     parking: true,
     poi: true,
     _traveltimeArrow: false,
+    _poiArrow: true,
   })
 })
 </script>

--- a/src/views/TravelTimesView.vue
+++ b/src/views/TravelTimesView.vue
@@ -29,6 +29,7 @@ onMounted(async () => {
     parking: false,
     poi: false,
     _traveltimeArrow: true,
+    _poiArrow: false,
   })
   state.travelTimes = await apiClientService.fetchTravelTime()
 })


### PR DESCRIPTION
<!-- Title must be: GSREN3D-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSREN3D-272

### Description

- Add an arrow from the current station to POIs that related to the station
- still has the same limitation for the arrow style (i.e. no offset from the starting point)

**Notes**
Not all station has POIs, so there is a possibility that you don't see the arrow if there are no POIs related to the station.

Suggestion: if there are no POIs, we can filter by distance.


### Screenshots

![image](https://user-images.githubusercontent.com/1421861/214206263-7fbc7cdf-faec-4b90-91cb-288c9b5846f2.png)

![image](https://user-images.githubusercontent.com/1421861/214206181-3aa51df6-b681-40ea-8af6-5e1f299e09fa.png)
